### PR TITLE
Update function-options.php

### DIFF
--- a/inc/function-options.php
+++ b/inc/function-options.php
@@ -53,7 +53,7 @@ class GOVPH
 
   public function __construct()
   {
-    $this->options = get_option('govph_options');
+    $this->options = get_option('govph_options', array());
     // to avoid warnings, reinstatiate all arrays that does not exist
     if(sizeof($this->options) > 0){
       $this->options = array_merge($this->_default_options, $this->options);


### PR DESCRIPTION
Added a default `array()` in so that the call to sizeof doesn’t fail.

When `gwt_options` does not exist the call to `get_option` returns `null` and the call to `sizeof` causes a crash since it requires an iteratable.